### PR TITLE
Signalmash authentication updates.

### DIFF
--- a/content/en/docs/getting-started/authentication/index.md
+++ b/content/en/docs/getting-started/authentication/index.md
@@ -20,15 +20,20 @@ Obtain API token credentials from the Signalmash Portal to get started. Then, yo
 
 #### 1. Obtain API token credentials from Signalmash Portal.
 
-To get token credentials, such as a **Token Name** and **API KEY** that are known to both Signalmash and your application, go to the Signalmash Portal (go to the API Menu and select "[Tokens](https://portal.signalmash.com/#/api/tokens)" from the submenu).
+To get token credentials, such as a **API KEY** that are known to both Signalmash and your application, go to the Signalmash Portal (go to the API Menu and select "[Tokens](https://portal.signalmash.com/#/api/tokens)" from the submenu).
 
 ![Signalmash Portal API tokens](api-keys.png)
 
-#### 2. Obtain a session token from Signalmash API login.
+#### 2. Include the API KEY in header when requesting to an API endpoints.
 
-#### 3. Send the access token to an API.
+For endpoints authentication, you will use your Signalmash API KEY as your Bearer token.
 
-#### 4. Refresh the access token, if necessary.
+```
+# Get all campaigns
+
+$ curl -X POST -H "Authorization: Bearer API_KEY" \
+    https://api.signalmash.com/campaigns
+```
 
 ### Revoking API Token
 

--- a/content/en/docs/getting-started/introduction.md
+++ b/content/en/docs/getting-started/introduction.md
@@ -58,6 +58,10 @@ There are many GUI tools available that are simpler to use than Curl. One of the
 
 ### Working with Webhooks
 
+Webhooks are user-defined HTTP callbacks triggered by an event in a web application. Signalmash uses webhooks to let your application know when events happen, like getting an incoming call or receiving an SMS message and SMS states. Webhooks are triggered asynchronously.
+
+To handle a webhook when you use Signalmash, you need to build a small web application that can accept HTTP POST requests.
+
 ### What to do next
 
 In this guide, we've introduced some of the fundamental concepts and resources you should be familiar with before using our APIs.


### PR DESCRIPTION
* since Signalmash deprecated /apilogin endpoints. you just need to include API KEY from Signalmash portal in your bearer token.